### PR TITLE
Compatibilité PluXml 5.5 et +

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+## version 1.3 (05/12/2018) ##
+Compatibilité PluXml 5.5 et (possiblement 5.6 et +)
+
 ## version 1.2 (20/05/2015) ##
 Compatibilité PluXml 5.4
 

--- a/infos.xml
+++ b/infos.xml
@@ -2,8 +2,8 @@
 <document>
 	<title><![CDATA[MyAkismet]]></title>
 	<author><![CDATA[Stéphane F.]]></author>
-	<version>1.2</version>
-	<date>20/05/2015</date>
+	<version>1.3</version>
+	<date>05/12/2018</date>
 	<site>http://pluxopolis.net</site>
 	<description><![CDATA[Akismet filters out your comment and track-back spam for you]]></description>
 	<requirements></requirements>

--- a/plxMyAkismet.php
+++ b/plxMyAkismet.php
@@ -78,11 +78,11 @@ class plxMyAkismet extends plxPlugin {
 			\$breadcrumbs[] = '<li><a '.(\$_SESSION['selCom']=='spam'?'class=\"selected\" ':'').'href=\"comments.php?sel=spam&amp;page=1\">Spam</a>&nbsp;('.\$plxAdmin->nbComments('/~[0-9]{4}.(.*).xml$/').')</li>';
 			function selectorSpam(\$id) {
 				ob_start();
-				plxUtils::printSelect('selection[]', array(''=> L_FOR_SELECTION, 'online' => L_COMMENT_SET_ONLINE, 'offline' => L_COMMENT_SET_OFFLINE,  '-'=>'-----','delete' => L_COMMENT_DELETE), '', false,'',\$id);
+				plxUtils::printSelect('selection', array(''=> L_FOR_SELECTION, 'online' => L_COMMENT_SET_ONLINE, 'offline' => L_COMMENT_SET_OFFLINE,  '-'=>'-----','delete' => L_COMMENT_DELETE), '', false,'no-margin',\$id);
 				return ob_get_clean();
 			}
 			if(\$comSel=='spam') {
-				\$selector1=selectorSpam('id_selection1');
+        		\$selector=selectorSpam('id_selection');
 			}
 		";
 		echo '<?php '.$string.' ?>';


### PR DESCRIPTION
Bonjour,
Dans l'état; plxMyAkismet fonctionnait toujours bien mais ne permettait plus les actions de lot comme "supprimer" plusieur messages. La liste déroulante avait disparu. J'ai utilisé ça pendant ces dernières années éditant les messages un par un et puis ce matin je me suis demandé si c'était à mon niveau de regarder sous le moteur et de réparer ça. J'ai galéré mais réussi à remettre ça sur pied un peu en regardant comment core/admin/comments.php avait evolué. Voici ma proposition testé sur 5.5 et probablement compatible pour les version plus récentes (5.6 et 5.7dev@git).